### PR TITLE
Small fixes + #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Obsidian TingPNG Plugin
+# Obsidian TinyPNG Plugin
 
 This streamlines Obsidian workflows by integrating TinyPNG's image compression service.
 
-**Note: This is NOT an official plugin from the TingPNG team. It is a community plugin.**
+**Note: This is NOT an official plugin from the TinyPNG team. It is a community plugin.**
 
 ## Installation
 
-You can install the Obsidian TingPNG Plugin by following these steps:
+You can install the Obsidian TinyPNG Plugin by following these steps:
 
 1. Download 3 files: `main.js`, `manifest.json`, `styles.css` from the [latest release](https://github.com/ckt1031/obsidian-tinypng-plugin/releases/latest).
 2. Create a folder named "obsidian-tinypng-plugin" in your Obsidian vault's plugins folder.
@@ -14,17 +14,17 @@ You can install the Obsidian TingPNG Plugin by following these steps:
 
 ## Configuration
 
-To configure the TingPNG plugin, you need to provide your API key and set the concurrency options. Here's how you can do it:
+To configure the TinyPNG plugin, you need to provide your API key and set the concurrency options. Here's how you can do it:
 
 1. Open the settings in Obsidian.
-2. Go to the "Plugins" section and find the TingPNG plugin.
+2. Go to the "Plugins" section and find the TinyPNG plugin.
 3. **Enter your API key** from [Tinify](https://tinify.com/dashboard/api) in the corresponding field.
 4. Choose the desired **concurrency level** from the options provided.
 5. Click the "Save" button to save your settings.
 
 ## Usage
 
-To compress images using the TingPNG plugin, follow these steps:
+To compress images using the TinyPNG plugin, follow these steps:
 
 1. Open Obsidian and navigate to the vault where your images are located.
 2. Press `Ctrl/Cmd + P` to open the command palette.
@@ -32,10 +32,10 @@ To compress images using the TingPNG plugin, follow these steps:
 4. The plugin will start compressing the images using the provided API key and concurrency options.
 5. Once the compression is complete, you will see a notification with the results.
 
-**Note: Make sure to review the TingPNG terms of service and API usage limits before using the plugin.**
+**Note: Make sure to review the TinyPNG terms of service and API usage limits before using the plugin.**
 
 ## Feedback and Support
 
-If you encounter any issues with the TingPNG plugin or have suggestions for improvements, please reach out to the community for support.
+If you encounter any issues with the TinyPNG plugin or have suggestions for improvements, please reach out to the community for support.
 
-**Disclaimer: This plugin is not affiliated with or endorsed by the TingPNG team. Use at your own risk.**
+**Disclaimer: This plugin is not affiliated with or endorsed by the TinyPNG team. Use at your own risk.**

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -19,8 +19,11 @@ export function getAllImages(plugin: TinypngPlugin) {
 }
 
 export function checkIsFileImage(plugin: TinypngPlugin, image: TFile) {
-	const extension = image.extension;
-	const customFormats = plugin.settings.extraImageFormats.split(',');
+	const extension = image.extension.toLowerCase();
+ 	const customFormats = plugin.settings.extraImageFormats
+ 		.split(',')
+ 		.map((format) => format.trim().toLowerCase())
+ 		.filter((format) => format.length > 0);
 	const isExtensionValid = [
 		...customFormats,
 		...defaultAllowedFormats,
@@ -54,7 +57,7 @@ export function checkIsFileImageAndAllowed(
 ) {
 	const isExtensionValid = checkIsFileImage(plugin, image);
 	const status = checkIsImageInSpecificFolder(plugin, image);
-	return isExtensionValid && !status;
+	return isExtensionValid && status;
 }
 
 export async function compressSingle(

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -20,10 +20,10 @@ export function getAllImages(plugin: TinypngPlugin) {
 
 export function checkIsFileImage(plugin: TinypngPlugin, image: TFile) {
 	const extension = image.extension.toLowerCase();
- 	const customFormats = plugin.settings.extraImageFormats
- 		.split(',')
- 		.map((format) => format.trim().toLowerCase())
- 		.filter((format) => format.length > 0);
+	const customFormats = plugin.settings.extraImageFormats
+		.split(',')
+		.map((format) => format.trim().toLowerCase())
+		.filter((format) => format.length > 0);
 	const isExtensionValid = [
 		...customFormats,
 		...defaultAllowedFormats,

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -56,8 +56,8 @@ export function checkIsFileImageAndAllowed(
 	image: TFile,
 ) {
 	const isExtensionValid = checkIsFileImage(plugin, image);
-	const status = checkIsImageInSpecificFolder(plugin, image);
-	return isExtensionValid && status;
+	const isInSpecificFolder = checkIsImageInSpecificFolder(plugin, image);
+	return isExtensionValid && isInSpecificFolder;
 }
 
 export async function compressSingle(


### PR DESCRIPTION
What this fixes:

1. **Bulk compression always returns 0/0/0**
   `checkIsFileImageAndAllowed()` was inverting the “allowed” result from `checkIsImageInSpecificFolder()`, causing `getAllImages()` to return an empty array. Corrected the boolean logic so allowed images are properly included. Addresses #57 by deleting a single character.

2. **Custom image formats fail when containing spaces**
   `extraImageFormats` parsing did not trim or normalize entries (e.g. `"png, webp"`). Added trimming, lowercasing, and empty-value filtering to ensure robust matching without changing settings behavior.

No schema changes. Behaviour now matches UI intent.
Also corrected the spelling of TinyPNG in the README.